### PR TITLE
🧪 Add test for get_number ValueError branch in pizza.py

### DIFF
--- a/IEEE Extreme/pizza.py
+++ b/IEEE Extreme/pizza.py
@@ -21,26 +21,27 @@ def get_number():
 import numpy as np
 #import scipy
 
-T = get_number()
-answers = np.zeros(T)
+if __name__ == '__main__':
+    T = get_number()
+    answers = np.zeros(T)
 
-for t in range(T):
-    N = get_number()
-    answer = 1
-    array = np.array([-1]*360, dtype=int)
+    for t in range(T):
+        N = get_number()
+        answer = 1
+        array = np.array([-1]*360, dtype=int)
 
-    for n in range(N):
-        D = get_number()
-        
-        boundedAngle = D % 180
-        if boundedAngle not in array:
-            array[boundedAngle] = boundedAngle
-            if answer == 1:
-                answer += 1
-            else:
-                answer += 2
+        for n in range(N):
+            D = get_number()
 
-    answers[t] = answer
+            boundedAngle = D % 180
+            if boundedAngle not in array:
+                array[boundedAngle] = boundedAngle
+                if answer == 1:
+                    answer += 1
+                else:
+                    answer += 2
 
-for ans in answers:
-    print(int(ans))
+        answers[t] = answer
+
+    for ans in answers:
+        print(int(ans))

--- a/IEEE Extreme/test_pizza.py
+++ b/IEEE Extreme/test_pizza.py
@@ -1,0 +1,15 @@
+import unittest
+from unittest.mock import patch
+import pizza
+
+class TestPizza(unittest.TestCase):
+    def test_get_number_int(self):
+        with patch('pizza.get_word', return_value='42'):
+            self.assertEqual(pizza.get_number(), 42)
+
+    def test_get_number_float(self):
+        with patch('pizza.get_word', return_value='3.14'):
+            self.assertEqual(pizza.get_number(), 3.14)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap in `get_number` was addressed by adding a test file that mocks `get_word` to return a string simulating a float, triggering the `ValueError` branch.
📊 **Coverage:** The unit tests now cover both the successful integer conversion and the fallback float conversion (when an integer conversion fails).
✨ **Result:** Increased test coverage and confidence in `get_number`'s error handling. As a bonus, `pizza.py` was refactored to wrap its execution logic in an `if __name__ == '__main__':` block, making it testable.

---
*PR created automatically by Jules for task [16525235316961780635](https://jules.google.com/task/16525235316961780635) started by @ManupaKDU*