### PR TITLE
🧹 Remove unused 're' import in Q5.py

### DIFF
--- a/Learning/Part-1/Python/Q5.py
+++ b/Learning/Part-1/Python/Q5.py
@@ -3,7 +3,6 @@
 import math
 import os
 import random
-import re
 import sys
 
 #


### PR DESCRIPTION
🎯 **What:** Removed the unused `import re` statement from `Learning/Part-1/Python/Q5.py`.
💡 **Why:** The `re` module was imported but never used anywhere in the file. Removing unused imports improves code readability, reduces namespace clutter, and conceptually slightly speeds up module initialization.
✅ **Verification:** Verified via `python3 -m py_compile` that the script syntax remains valid. Ran the repository test suite to confirm no regressions occurred. Cleaned up compiled binary files generated during tests so they aren't tracked.
✨ **Result:** A cleaner script that only imports the modules it actively requires.

---
*PR created automatically by Jules for task [13725669920157673328](https://jules.google.com/task/13725669920157673328) started by @ManupaKDU*