### PR TITLE
🔒 Fix hardcoded default password hash in Test-1.py

### DIFF
--- a/Part-1/wHATTA/Basics/Test-1.py
+++ b/Part-1/wHATTA/Basics/Test-1.py
@@ -6,9 +6,9 @@ import sys
 def check_password(entered_password, stored_hash):
     return hashlib.sha256(entered_password.encode()).hexdigest() == stored_hash
 
-# Default hash for password '9'
-DEFAULT_HASH = "19581e27de7ced00ff1ce50b2047e7a567c76b1cbaebabe5ef03f7c3017bb5b7"
-stored_password_hash = os.environ.get("APP_PASSWORD_HASH", DEFAULT_HASH)
+stored_password_hash = os.environ.get("APP_PASSWORD_HASH")
+if not stored_password_hash:
+    raise RuntimeError("APP_PASSWORD_HASH environment variable is not set")
 
 def secure_input(prompt):
     if sys.stdin.isatty():

--- a/Part-1/wHATTA/Basics/test_Test_1.py
+++ b/Part-1/wHATTA/Basics/test_Test_1.py
@@ -1,21 +1,24 @@
 import unittest
 import importlib
 import hashlib
+import os
+
+TEST_HASH = "19581e27de7ced00ff1ce50b2047e7a567c76b1cbaebabe5ef03f7c3017bb5b7"
+os.environ["APP_PASSWORD_HASH"] = TEST_HASH
 
 # Import the module with a hyphen in the name
 test_1 = importlib.import_module("Part-1.wHATTA.Basics.Test-1")
 check_password = test_1.check_password
-DEFAULT_HASH = test_1.DEFAULT_HASH
 
 class TestCheckPassword(unittest.TestCase):
     def test_correct_password(self):
-        self.assertTrue(check_password("9", DEFAULT_HASH))
+        self.assertTrue(check_password("9", TEST_HASH))
 
     def test_incorrect_password(self):
-        self.assertFalse(check_password("wrongpassword", DEFAULT_HASH))
+        self.assertFalse(check_password("wrongpassword", TEST_HASH))
 
     def test_empty_password(self):
-        self.assertFalse(check_password("", DEFAULT_HASH))
+        self.assertFalse(check_password("", TEST_HASH))
 
     def test_different_valid_hash(self):
         password = "newpassword123"


### PR DESCRIPTION
🎯 **What:** Removed the hardcoded `DEFAULT_HASH` from `Test-1.py` which was being used as a fallback if the `APP_PASSWORD_HASH` environment variable was not set.
⚠️ **Risk:** Hardcoded authentication secrets pose a significant security risk. If an attacker gains access to the source code or if the application is deployed without explicitly setting the environment variable, the system falls back to a known password ('9' in this case), allowing unauthorized access.
🛡️ **Solution:** The fallback logic was eliminated. The script now reads strictly from the `APP_PASSWORD_HASH` environment variable and actively raises a `RuntimeError` if it is missing, enforcing secure configuration. The unit tests were also updated to dynamically set the environment variable prior to importing the module, isolating the tests from the removed constant and preventing import-time crashes.

---
*PR created automatically by Jules for task [11969418054044019928](https://jules.google.com/task/11969418054044019928) started by @ManupaKDU*