### PR TITLE
Remove path backward compatibility hack

### DIFF
--- a/Learning/Part-1/Lib/site-packages/urllib3/util/url.py
+++ b/Learning/Part-1/Lib/site-packages/urllib3/util/url.py
@@ -391,15 +391,8 @@ def parse_url(url):
     except (ValueError, AttributeError):
         return six.raise_from(LocationParseError(source_url), None)
 
-    # For the sake of backwards compatibility we put empty
-    # string values for path if there are any defined values
-    # beyond the path in the URL.
-    # TODO: Remove this when we break backwards compatibility.
     if not path:
-        if query is not None or fragment is not None:
-            path = ""
-        else:
-            path = None
+        path = None
 
     # Ensure that each part of the URL is a `str` for
     # backwards compatibility.


### PR DESCRIPTION
Removes the backward compatibility hack in `urllib3/util/url.py` when parsing URLs, aligning with breaking changes in the major version bump.

---
*PR created automatically by Jules for task [10948267651041784310](https://jules.google.com/task/10948267651041784310) started by @ManupaKDU*