### PR TITLE
🧹 [code health improvement] Replace wildcard import with specific import

### DIFF
--- a/Part-1/wHATTA/Basics/Learn Giraffe.py
+++ b/Part-1/wHATTA/Basics/Learn Giraffe.py
@@ -1,4 +1,4 @@
-from math import *
+from math import factorial
 feds = [0 , 10]
 print(feds[1: 9])
 print(factorial(6))


### PR DESCRIPTION
🎯 **What:** Replaced the wildcard import `from math import *` with a specific import `from math import factorial` in `Learn Giraffe.py`.
💡 **Why:** Using wildcard imports makes it unclear which functions are being brought into the namespace and can lead to naming collisions. Since only `factorial` is used from the `math` module in this script, importing it explicitly improves readability and maintainability.
✅ **Verification:** Ran `python3 "Part-1/wHATTA/Basics/Learn Giraffe.py"` locally to confirm the original functionality and output are fully preserved without errors.
✨ **Result:** A cleaner namespace with clear, explicit dependencies.

---
*PR created automatically by Jules for task [1756346759526215392](https://jules.google.com/task/1756346759526215392) started by @ManupaKDU*