### PR TITLE
🧹 Remove unused imports in assign4.py

### DIFF
--- a/Learning/Part-1/Python/assign4.py
+++ b/Learning/Part-1/Python/assign4.py
@@ -1,5 +1,3 @@
-import wave
-import struct
 import numpy as np
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
🎯 **What:** Removed unused `wave` and `struct` imports from `Learning/Part-1/Python/assign4.py`.
💡 **Why:** These modules were imported but never used in the script, as it only utilizes `numpy` and `matplotlib.pyplot`. Removing them improves code maintainability and readability by eliminating unnecessary dependencies.
✅ **Verification:** Verified the python syntax using `python3 -m py_compile` and ran the full unit test suite, confirming that the change is completely safe and no regressions were introduced.
✨ **Result:** A cleaner script with only its actual dependencies imported.

---
*PR created automatically by Jules for task [18051766797554887107](https://jules.google.com/task/18051766797554887107) started by @ManupaKDU*