### PR TITLE
🔒 Fix insecure password hashing in Test-1.py

### DIFF
--- a/Part-1/wHATTA/Basics/Test-1.py
+++ b/Part-1/wHATTA/Basics/Test-1.py
@@ -2,9 +2,21 @@ import hashlib
 import os
 import getpass
 import sys
+import secrets
+import binascii
+
+def hash_password(password):
+    salt = secrets.token_hex(16)
+    pwd_hash = hashlib.pbkdf2_hmac('sha256', password.encode('utf-8'), salt.encode('utf-8'), 100000)
+    return f"{salt}:{binascii.hexlify(pwd_hash).decode('ascii')}"
 
 def check_password(entered_password, stored_hash):
-    return hashlib.sha256(entered_password.encode()).hexdigest() == stored_hash
+    try:
+        salt, hash_hex = stored_hash.split(':', 1)
+        pwd_hash = hashlib.pbkdf2_hmac('sha256', entered_password.encode('utf-8'), salt.encode('utf-8'), 100000)
+        return secrets.compare_digest(binascii.hexlify(pwd_hash).decode('ascii'), hash_hex)
+    except ValueError:
+        return False
 
 stored_password_hash = os.environ.get("APP_PASSWORD_HASH")
 if not stored_password_hash:

--- a/Part-1/wHATTA/Basics/test_Test_1.py
+++ b/Part-1/wHATTA/Basics/test_Test_1.py
@@ -3,12 +3,13 @@ import importlib
 import hashlib
 import os
 
-TEST_HASH = "19581e27de7ced00ff1ce50b2047e7a567c76b1cbaebabe5ef03f7c3017bb5b7"
+TEST_HASH = "d48c4268e1cfaa8ddb4a1643d07d6638:18fe6b1d28b7727f534db9b9158dce9238c7a5e52093ee1cdf7c902f9ffb4258"
 os.environ["APP_PASSWORD_HASH"] = TEST_HASH
 
 # Import the module with a hyphen in the name
 test_1 = importlib.import_module("Part-1.wHATTA.Basics.Test-1")
 check_password = test_1.check_password
+hash_password = test_1.hash_password
 
 class TestCheckPassword(unittest.TestCase):
     def test_correct_password(self):
@@ -22,12 +23,12 @@ class TestCheckPassword(unittest.TestCase):
 
     def test_different_valid_hash(self):
         password = "newpassword123"
-        expected_hash = hashlib.sha256(password.encode()).hexdigest()
+        expected_hash = hash_password(password)
         self.assertTrue(check_password(password, expected_hash))
 
     def test_special_characters(self):
         password = "!@#$%^&*()_+"
-        expected_hash = hashlib.sha256(password.encode()).hexdigest()
+        expected_hash = hash_password(password)
         self.assertTrue(check_password(password, expected_hash))
 
 if __name__ == '__main__':


### PR DESCRIPTION
🎯 **What:** The `check_password` function in `Part-1/wHATTA/Basics/Test-1.py` was using raw SHA-256 for password hashing.
⚠️ **Risk:** Raw SHA-256 without a salt is vulnerable to dictionary attacks and rainbow tables. An attacker could precompute hashes or use existing databases to reverse the hash. Additionally, simple equality comparison (`==`) is vulnerable to timing attacks.
🛡️ **Solution:** Replaced raw SHA-256 with `hashlib.pbkdf2_hmac` using a 16-byte random salt generated by `secrets.token_hex` and 100,000 iterations. The comparison now uses `secrets.compare_digest` to prevent timing attacks. Updated unit tests to support the new `<salt>:<hash>` format.

---
*PR created automatically by Jules for task [3853872340129879904](https://jules.google.com/task/3853872340129879904) started by @ManupaKDU*