### PR TITLE
fix: Remove 'Hack' keyword from comment

### DIFF
--- a/Part-1/wHATTA/GUI Basics/1.py
+++ b/Part-1/wHATTA/GUI Basics/1.py
@@ -10,6 +10,6 @@ top.geometry('1920x1080')
 #Here we define a variable to act as the label displayed on the window as "Hello World
 bt = tkinter.Button (top,text="Hack!")
 bt.grid(column = 1 ,row = 0)
-#This represents the the button as "Hack"
+#This represents the button text.
 top.mainloop()
 #This ends the program drawning code from the library


### PR DESCRIPTION
Resolves a mistakenly flagged 'HACK' marker in a code comment.

The comment in `Part-1/wHATTA/GUI Basics/1.py` explained the button text but triggered an automated keyword scanner for the word 'HACK'. The comment has been updated to `#This represents the button text.` to convey the same meaning without using the flagged keyword.

Also fixed a minor typo ("the the") in the original comment.

---
*PR created automatically by Jules for task [16707170630024108965](https://jules.google.com/task/16707170630024108965) started by @ManupaKDU*