### PR TITLE
🧹 Fix dead code true literal to be a continue on user reset

### DIFF
--- a/Learning/Part-1/Python/test.py
+++ b/Learning/Part-1/Python/test.py
@@ -127,4 +127,4 @@ if __name__ == '__main__':
                         c2 = True
             other(choice,a,b)
         elif(select_op(choice) == 1):
-            True
+            continue


### PR DESCRIPTION
🎯 **What:** Replaced the dead code `True` expression with a functionally descriptive `continue` statement within the inner CLI interactive loop handling reset action in `Learning/Part-1/Python/test.py`.
💡 **Why:** `True` being used on a single line evaluates to a no-op boolean, adding unnecessary parsing clutter. Since `select_op` outputs 1 when an unrecognized operation (`$`) resets the inputs, `continue` perfectly represents restarting the `while` block, thus removing a source of dead code ambiguity and making it more understandable to other developers maintaining this file.
✅ **Verification:** Ran `python3 Learning/Part-1/Python/test.py` via piping the `$`, verifying it correctly forces a prompt refresh on valid inputs. Tested alongside running all `test_*.py` files in subdirectories (`unittest discover` using dynamic env logic mapped) to ensure there are no regressions. Tested successfully.
✨ **Result:** Better control flow handling when parsing invalid inputs or when specifically triggering the reset choice (`$`) within `test.py` which will no longer output linter errors for unreachable code evaluations.

---
*PR created automatically by Jules for task [8049523599414608292](https://jules.google.com/task/8049523599414608292) started by @ManupaKDU*