### PR TITLE
🔒 Fix Data Exposure: Broad Exception Catching in Calexpected

### DIFF
--- a/Learning/Part-1/Python/Calexpected by author.py
+++ b/Learning/Part-1/Python/Calexpected by author.py
@@ -10,8 +10,8 @@ def multiply (a,b):
 def divide(a,b):
   try:
     return a/b
-  except Exception as e:
-    print(e)
+  except ZeroDivisionError:
+    print("float division by zero")
 def power(a,b):
   return a**b
   

--- a/Learning/Part-1/Python/test_calexpected.py
+++ b/Learning/Part-1/Python/test_calexpected.py
@@ -1,0 +1,42 @@
+import unittest
+import sys
+import io
+import os
+import importlib.util
+from unittest.mock import patch
+
+class TestCalexpected(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Mock input to return '7' (Terminate: #) and exit immediately
+        # Mock sys.stdout to prevent printing
+        with patch('builtins.input', side_effect=['#']), \
+             patch('sys.stdout', new_callable=io.StringIO):
+
+            # Load the module dynamically due to spaces in filename
+            module_name = "calexpected_by_author"
+            file_path = os.path.join(os.path.dirname(__file__), "Calexpected by author.py")
+            spec = importlib.util.spec_from_file_location(module_name, file_path)
+            cls.cal_module = importlib.util.module_from_spec(spec)
+
+            try:
+                spec.loader.exec_module(cls.cal_module)
+            except SystemExit:
+                pass
+
+    def test_divide_normal(self):
+        result = self.cal_module.divide(10, 2)
+        self.assertEqual(result, 5.0)
+
+    def test_divide_by_zero(self):
+        # We need to test the printed output
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            result = self.cal_module.divide(10, 0)
+            self.assertIsNone(result)
+            output = mock_stdout.getvalue().strip()
+            # When the raw ZeroDivisionError exception object is printed, it says "division by zero" or "float division by zero"
+            # Since we will change it to print "float division by zero", the test will check for that.
+            self.assertEqual(output, "float division by zero")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The `divide` function in `Calexpected by author.py` caught broad `Exception` objects and exposed them by printing them directly to standard output. This has been updated to specifically catch `ZeroDivisionError` and print a generic `"float division by zero"` string. A dedicated suite of tests was also added.
⚠️ **Risk:** Catching all exceptions masks critical system errors and makes debugging significantly harder. Moreover, printing raw exception objects can leak unexpected stack trace information or underlying interpreter details to end-users.
🛡️ **Solution:** The overly broad exception handling was replaced with a focused `except ZeroDivisionError:` clause, and the raw print statement was replaced with a safe, statically-typed error string to guarantee no accidental data leakage. Tests using `unittest` and mock objects were added to ensure the functionality persists and the vulnerability remains fixed.

---
*PR created automatically by Jules for task [18403978050284619542](https://jules.google.com/task/18403978050284619542) started by @ManupaKDU*