### PR TITLE
🧹 Refactor `test_basic_program.py` to remove unused `sys` import

### DIFF
--- a/Part-1/wHATTA/Basics/test_basic_program.py
+++ b/Part-1/wHATTA/Basics/test_basic_program.py
@@ -1,10 +1,12 @@
 import unittest
-import importlib
-import sys
+import importlib.util
 import os
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-basic_program = importlib.import_module('Basic Program')
+module_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'Basic Program.py')
+spec = importlib.util.spec_from_file_location('basic_program', module_path)
+basic_program = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(basic_program)
+
 max_num = basic_program.max_num
 
 class TestMaxNum(unittest.TestCase):


### PR DESCRIPTION
🎯 **What:** Removed the unused `sys` import in `Part-1/wHATTA/Basics/test_basic_program.py`.
💡 **Why:** `sys` was previously used by `sys.path.append` to resolve an import path. Refactoring this to use the cleaner and safer `importlib.util.spec_from_file_location` eliminates the need to pollute `sys.path` and removes the unused `sys` import, improving code maintainability.
✅ **Verification:** Ran `python3 Part-1/wHATTA/Basics/test_basic_program.py` and the full test suite locally, confirming 0 regressions and identical behavior.
✨ **Result:** A cleaner test script with removed dead imports and improved dynamic loading.

---
*PR created automatically by Jules for task [7442828534552631224](https://jules.google.com/task/7442828534552631224) started by @ManupaKDU*