### PR TITLE
🧪 Add Division By Zero Error Path Test for Calexpected

### DIFF
--- a/Learning/Part-1/Python/Calexpected by author.py
+++ b/Learning/Part-1/Python/Calexpected by author.py
@@ -73,21 +73,25 @@ def select_op(choice):
   else:
     print("Unrecognized operation")
     
-while True:
-  print("Select operation.")
-  print("1.Add      : + ")
-  print("2.Subtract : - ")
-  print("3.Multiply : * ")
-  print("4.Divide   : / ")
-  print("5.Power    : ^ ")
-  print("6.Remainder: % ")
-  print("7.Terminate: # ")
-  print("8.Reset    : $ ")
-  
-  # take input from the user
-  choice = input("Enter choice(+,-,*,/,^,%,#,$): ")
-  print(choice)
-  if(select_op(choice) == -1):
-    #program ends here
-    print("Done. Terminating")
-    exit()
+def main():
+  while True:
+    print("Select operation.")
+    print("1.Add      : + ")
+    print("2.Subtract : - ")
+    print("3.Multiply : * ")
+    print("4.Divide   : / ")
+    print("5.Power    : ^ ")
+    print("6.Remainder: % ")
+    print("7.Terminate: # ")
+    print("8.Reset    : $ ")
+
+    # take input from the user
+    choice = input("Enter choice(+,-,*,/,^,%,#,$): ")
+    print(choice)
+    if(select_op(choice) == -1):
+      #program ends here
+      print("Done. Terminating")
+      exit()
+
+if __name__ == "__main__":
+  main()

--- a/Learning/Part-1/Python/test_calexpected_by_author.py
+++ b/Learning/Part-1/Python/test_calexpected_by_author.py
@@ -1,0 +1,26 @@
+import unittest
+import importlib.util
+import os
+import io
+from unittest.mock import patch
+
+class TestCalexpected(unittest.TestCase):
+    def setUp(self):
+        module_name = 'calexpected'
+        file_path = os.path.join(os.path.dirname(__file__), 'Calexpected by author.py')
+        spec = importlib.util.spec_from_file_location(module_name, file_path)
+        self.calc_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.calc_module)
+
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_divide_by_zero_error_path(self, mock_stdout):
+        # The divide function tries a/b and catches Exception e, printing e
+        result = self.calc_module.divide(10, 0)
+        output = mock_stdout.getvalue()
+
+        # When printing Exception("division by zero"), it's printed to stdout
+        self.assertIsNone(result)
+        self.assertIn("division by zero", output.lower())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap for testing the divide-by-zero error path in `divide(a,b)` in `Calexpected by author.py` was addressed. Since the method suppresses exceptions and prints them instead of re-raising, standard Exception `assertRaises` does not work.
📊 **Coverage:** A new test `test_divide_by_zero_error_path` tests that `divide(10, 0)` returns `None` and correctly prints the `"division by zero"` error to output, dynamically loading the module.
✨ **Result:** Increased testing coverage for the failure/exception states of the calculator. Also refactored `Calexpected by author.py` logic to live within `if __name__ == '__main__':` to allow for clean module loading.

---
*PR created automatically by Jules for task [7970311108863089251](https://jules.google.com/task/7970311108863089251) started by @ManupaKDU*