### PR TITLE
🧹 Refactor test_basic_program module loading and remove unused sys import

### DIFF
--- a/Part-1/wHATTA/Basics/test_basic_program.py
+++ b/Part-1/wHATTA/Basics/test_basic_program.py
@@ -1,11 +1,17 @@
 import unittest
-import importlib
-import sys
+import importlib.util
 import os
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-basic_program = importlib.import_module('Basic Program')
+current_dir = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location(
+    "Basic_Program",
+    os.path.join(current_dir, "Basic Program.py")
+)
+basic_program = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(basic_program)
+
 max_num = basic_program.max_num
+
 
 class TestMaxNum(unittest.TestCase):
     def test_max_num_first(self):
@@ -29,6 +35,7 @@ class TestMaxNum(unittest.TestCase):
         self.assertEqual(max_num(-1, -2, -3), -1)
         self.assertEqual(max_num(-3, -1, -2), -1)
         self.assertEqual(max_num(-3, -2, -1), -1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Refactored `test_basic_program.py` to remove the `sys` import and `sys.path.append(...)` statement which was a hack used to resolve module loading. Updated the test to use `importlib.util.spec_from_file_location`, eliminating the unused `sys` import entirely while properly utilizing the existing `os` import to safely locate and resolve the filename containing spaces. Also cleaned up whitespace styling to comply with PEP8 requirements using flake8.

💡 **Why:** How this improves maintainability
The `os` import was actually being used on line 6 `os.path.dirname(os.path.abspath(__file__))`, but the `sys` import was only being used to manipulate `sys.path`, which pollutes the global python path and introduces side effects when the test runs. Swapping to the modern `importlib.util` dynamic imports resolves the `sys.path` side effects and makes module loading explicitly point to the target file.

✅ **Verification:** How you confirmed the change is safe
Ran the explicit unit test (`python3 Part-1/wHATTA/Basics/test_basic_program.py`) and all tests passed (`6 tests in 0.000s OK`). Ran the `flake8` linter which returned no unused import or styling warnings. Finally ran the repository-wide test suite using the find module loader which successfully ran without introducing new regressions.

✨ **Result:** The improvement achieved
A cleaner test execution with zero global path modifications, explicitly resolving the file path loading using `importlib.util` which prevents potential path leakages and side-effects.

---
*PR created automatically by Jules for task [2446234848316759561](https://jules.google.com/task/2446234848316759561) started by @ManupaKDU*