### PR TITLE
🧹 [Fix empty acmTeam function placeholder]

### DIFF
--- a/Learning/Part-1/Python/Q5.py
+++ b/Learning/Part-1/Python/Q5.py
@@ -10,7 +10,25 @@ import os
 #
 
 def acmTeam(topic):
-    print("")
+    n = len(topic)
+    max_topics = 0
+    teams_count = 0
+
+    # Convert strings to integers for faster bitwise operations
+    ints = [int(t, 2) for t in topic]
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            # Bitwise OR and count the 1s
+            topics_known = (ints[i] | ints[j]).bit_count()
+
+            if topics_known > max_topics:
+                max_topics = topics_known
+                teams_count = 1
+            elif topics_known == max_topics:
+                teams_count += 1
+
+    return [max_topics, teams_count]
 
 if __name__ == '__main__':
     fptr = open(os.environ['OUTPUT_PATH'], 'w')

--- a/Learning/Part-1/Python/test_Q5.py
+++ b/Learning/Part-1/Python/test_Q5.py
@@ -1,0 +1,22 @@
+import unittest
+from Q5 import acmTeam
+
+class TestQ5(unittest.TestCase):
+    def test_acmTeam(self):
+        topic = ['10101', '11100', '11010', '00101']
+        result = acmTeam(topic)
+        self.assertEqual(result, [5, 2])
+
+    def test_acmTeam_all_ones(self):
+        topic = ['111', '111', '111']
+        result = acmTeam(topic)
+        # 3 teams, all know 3 topics
+        self.assertEqual(result, [3, 3])
+
+    def test_acmTeam_all_zeros(self):
+        topic = ['000', '000']
+        result = acmTeam(topic)
+        self.assertEqual(result, [0, 1])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Replaced the empty `acmTeam` function placeholder in `Learning/Part-1/Python/Q5.py` with the complete implementation. Added a test file `test_Q5.py` to cover normal and edge cases.
💡 **Why:** The original function was simply printing `""`, violating the expected contract of returning an integer array containing the maximum number of topics a team can know and the number of teams that know that maximum. Implementing it corrects the logic and ensures the function handles its expected responsibilities properly.
✅ **Verification:** Wrote `test_Q5.py` unit tests covering multiple scenarios (typical arrays, all 1s, all 0s) and executed them successfully. Furthermore, the entire suite was executed via `python3 -m unittest` ensuring no regressions.
✨ **Result:** The `acmTeam` function now accurately calculates the maximum possible topics known by any two-person team and correctly counts how many teams achieve this maximum, passing all targeted tests.

---
*PR created automatically by Jules for task [213696664177941083](https://jules.google.com/task/213696664177941083) started by @ManupaKDU*