### PR TITLE
🔒 Fix bare except vulnerability in test.py

### DIFF
--- a/Learning/Part-1/Python/test.py
+++ b/Learning/Part-1/Python/test.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
                     a = float(a)
                     c1 = False
                     c2 = True
-                except:
+                except ValueError:
                     if(a[-1]=='$'):
                         choice = '$'
                         select_op(choice)
@@ -111,7 +111,7 @@ if __name__ == '__main__':
                 try:
                     b = float(b)
                     c2 = False
-                except:
+                except ValueError:
                     if(b[-1]=="$"):
                         choice = '$'
                         select_op(choice)


### PR DESCRIPTION
🎯 **What:** Fixed bare except blocks on line 96 and 114 in `Learning/Part-1/Python/test.py`.
⚠️ **Risk:** The use of bare excepts catches everything, including system-level exceptions like `KeyboardInterrupt` or `SystemExit`. This can cause programs to hang, ignore termination signals, or hide critical errors, presenting a reliability and security risk.
🛡️ **Solution:** Replaced the bare `except:` statements with specific `except ValueError:` clauses, since the try block attempts to cast a user-provided string to a float using `float()`, which exclusively raises `ValueError` on bad formats. This preserves functionality while explicitly defining expected errors and allowing critical exceptions to propagate.

---
*PR created automatically by Jules for task [10645583852230040079](https://jules.google.com/task/10645583852230040079) started by @ManupaKDU*