### PR TITLE
🧹 Refactor bare except to ValueError in test.py

### DIFF
--- a/Learning/Part-1/Python/test.py
+++ b/Learning/Part-1/Python/test.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
                     a = float(a)
                     c1 = False
                     c2 = True
-                except:
+                except ValueError:
                     if(a[-1]=='$'):
                         choice = '$'
                         select_op(choice)
@@ -111,7 +111,7 @@ if __name__ == '__main__':
                 try:
                     b = float(b)
                     c2 = False
-                except:
+                except ValueError:
                     if(b[-1]=="$"):
                         choice = '$'
                         select_op(choice)


### PR DESCRIPTION
🎯 **What:** Replaced bare `except:` clauses with `except ValueError:` in `Learning/Part-1/Python/test.py` at lines 96 and 114.
💡 **Why:** A bare `except:` catches all exceptions, including `SystemExit` and `KeyboardInterrupt`, which can make debugging difficult and hide critical system errors. Since the `try` block only attempts to convert user input to a float (`float(a)` and `float(b)`), specifying `except ValueError:` ensures that only the expected type conversion errors are handled, improving code safety and maintainability.
✅ **Verification:** Verified the fix by running format and lint checks (`flake8`), which confirmed the removal of the E722 warning. Ran the full test suite (`find . -name "test_*.py" -print0 | xargs -0 -n1 python3 -m unittest`) and confirmed that all 16 test files, including the test file for this specific calculator, passed successfully without regressions.
✨ **Result:** Improved code health and safety by preventing the masking of unexpected exceptions while preserving existing behavior.

---
*PR created automatically by Jules for task [5682880834720934566](https://jules.google.com/task/5682880834720934566) started by @ManupaKDU*