### PR TITLE
🔒 Fix bare except vulnerabilities in test.py

### DIFF
--- a/Learning/Part-1/Python/test.py
+++ b/Learning/Part-1/Python/test.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
                     a = float(a)
                     c1 = False
                     c2 = True
-                except:
+                except Exception:
                     if(a[-1]=='$'):
                         choice = '$'
                         select_op(choice)
@@ -111,7 +111,7 @@ if __name__ == '__main__':
                 try:
                     b = float(b)
                     c2 = False
-                except:
+                except Exception:
                     if(b[-1]=="$"):
                         choice = '$'
                         select_op(choice)


### PR DESCRIPTION
🎯 **What:** Replaced bare `except:` statements with `except Exception:` in `Learning/Part-1/Python/test.py`.

⚠️ **Risk:** Bare except blocks indiscriminately catch all exceptions, including `KeyboardInterrupt` (Ctrl+C), `SystemExit`, and memory errors. This makes it impossible to terminate the program gracefully, hides critical runtime failures, and is a security and reliability anti-pattern that can mask deeper issues or cause denial of service.

🛡️ **Solution:** By changing `except:` to `except Exception:`, we only catch standard program errors (like the `ValueError` expected when `float()` fails on non-numeric input). This preserves the intended application flow while allowing system-level signals to propagate normally.

---
*PR created automatically by Jules for task [14579649981501647548](https://jules.google.com/task/14579649981501647548) started by @ManupaKDU*