### PR TITLE
Add logging to cachecontrol filewrapper

### DIFF
--- a/Learning/Part-1/Lib/site-packages/pip-19.0.3-py3.8.egg/pip/_vendor/cachecontrol/filewrapper.py
+++ b/Learning/Part-1/Lib/site-packages/pip-19.0.3-py3.8.egg/pip/_vendor/cachecontrol/filewrapper.py
@@ -1,4 +1,7 @@
 from io import BytesIO
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class CallbackFileWrapper(object):
@@ -44,7 +47,7 @@ class CallbackFileWrapper(object):
             pass
 
         # We just don't cache it then.
-        # TODO: Add some logging here...
+        logger.debug("Unable to determine whether fp is closed.")
         return False
 
     def _close(self):


### PR DESCRIPTION
Added `import logging` and a debug logging statement in `CallbackFileWrapper.__is_fp_closed()` to track when it cannot determine if a file pointer is closed, replacing an old `TODO` comment.

---
*PR created automatically by Jules for task [12503730258372256165](https://jules.google.com/task/12503730258372256165) started by @ManupaKDU*