### PR TITLE
feat: add optional socket.gethostbyname checking to is_same_host in urllib3

### DIFF
--- a/Learning/Part-1/Lib/site-packages/urllib3/connectionpool.py
+++ b/Learning/Part-1/Lib/site-packages/urllib3/connectionpool.py
@@ -475,7 +475,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         except queue.Empty:
             pass  # Done.
 
-    def is_same_host(self, url):
+    def is_same_host(self, url, host_check=False):
         """
         Check if the given ``url`` is a member of the same host as this
         connection pool.
@@ -483,7 +483,6 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         if url.startswith("/"):
             return True
 
-        # TODO: Add optional support for socket.gethostbyname checking.
         scheme, host, port = get_host(url)
         if host is not None:
             host = _normalize_host(host, scheme=scheme)
@@ -494,7 +493,19 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         elif not self.port and port == port_by_scheme.get(scheme):
             port = None
 
-        return (scheme, host, port) == (self.scheme, self.host, self.port)
+        if (scheme, host, port) == (self.scheme, self.host, self.port):
+            return True
+
+        if host_check and host is not None and self.host is not None:
+            try:
+                host_ip = socket.gethostbyname(host)
+                self_host_ip = socket.gethostbyname(self.host)
+                if (scheme, host_ip, port) == (self.scheme, self_host_ip, self.port):
+                    return True
+            except socket.error:
+                pass
+
+        return False
 
     def urlopen(
         self,

--- a/test_is_same_host2.py
+++ b/test_is_same_host2.py
@@ -1,0 +1,62 @@
+import sys
+
+# We can directly instantiate connectionpool because we only need is_same_host
+# Let's bypass urllib3 __init__ by extracting the is_same_host logic to test
+
+from urllib.parse import urlparse
+import socket
+
+def _normalize_host(host, scheme):
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
+    if scheme in ("http", "https"):
+        host = host.lower()
+    return host
+
+def get_host(url):
+    p = urlparse(url)
+    return p.scheme or None, p.hostname or None, p.port or None
+
+port_by_scheme = {"http": 80, "https": 443}
+
+class DummyPool:
+    def __init__(self, scheme, host, port):
+        self.scheme = scheme
+        self.host = host
+        self.port = port
+
+    def is_same_host(self, url, host_check=False):
+        if url.startswith("/"):
+            return True
+
+        scheme, host, port = get_host(url)
+        if host is not None:
+            host = _normalize_host(host, scheme=scheme)
+
+        # Use explicit default port for comparison when none is given
+        if self.port and not port:
+            port = port_by_scheme.get(scheme)
+        elif not self.port and port == port_by_scheme.get(scheme):
+            port = None
+
+        if (scheme, host, port) == (self.scheme, self.host, self.port):
+            return True
+
+        if host_check and host is not None and self.host is not None:
+            try:
+                host_ip = socket.gethostbyname(host)
+                self_host_ip = socket.gethostbyname(self.host)
+                if (scheme, host_ip, port) == (self.scheme, self_host_ip, self.port):
+                    return True
+            except socket.error:
+                pass
+
+        return False
+
+pool = DummyPool("http", "localhost", 80)
+print(f"Same string, default host_check: {pool.is_same_host('http://localhost:80/')}")
+print(f"Diff string, default host_check: {pool.is_same_host('http://127.0.0.1:80/')}")
+print(f"Diff string, host_check=True: {pool.is_same_host('http://127.0.0.1:80/', host_check=True)}")
+
+pool_ip = DummyPool("http", "127.0.0.1", 80)
+print(f"Diff string 2, host_check=True: {pool_ip.is_same_host('http://localhost:80/', host_check=True)}")


### PR DESCRIPTION
What:
Added an optional parameter `host_check` to `ConnectionPool.is_same_host` in `urllib3/connectionpool.py`. When enabled, if the standard URL parsing mismatch occurs, the method falls back to verifying whether the resolved IP addresses (via `socket.gethostbyname`) match. 

Why:
To fulfill an existing `TODO` comment requesting optional support for `socket.gethostbyname` checking, allowing `is_same_host` to recognize two different hostnames that map to the exact same server (e.g., `localhost` and `127.0.0.1`) when requested by the consumer.

Verification:
- Manually created a test script simulating the pool logic to verify `localhost` and `127.0.0.1` properly evaluate as the same host when `host_check=True`.
- Validated backwards compatibility (default `host_check=False` maintains previous exact-match string logic).
- Handled network/resolution failures safely by catching `socket.error` and falling back to returning `False`.
- Ran the full available test suite to ensure no structural regressions were introduced.

Result:
The method now safely supports optional host checking without breaking existing logic, satisfying the requirement cleanly.

---
*PR created automatically by Jules for task [1482492645477089160](https://jules.google.com/task/1482492645477089160) started by @ManupaKDU*