### PR TITLE
Include URL in ReadTimeoutError

### DIFF
--- a/Learning/Part-1/Lib/site-packages/urllib3/response.py
+++ b/Learning/Part-1/Lib/site-packages/urllib3/response.py
@@ -437,9 +437,7 @@ class HTTPResponse(io.IOBase):
                 yield
 
             except SocketTimeout:
-                # FIXME: Ideally we'd like to include the url in the ReadTimeoutError but
-                # there is yet no clean way to get at it from this context.
-                raise ReadTimeoutError(self._pool, None, "Read timed out.")
+                raise ReadTimeoutError(self._pool, self._request_url, "Read timed out.")
 
             except BaseSSLError as e:
                 # FIXME: Is there a better way to differentiate between SSLErrors?
@@ -448,7 +446,7 @@ class HTTPResponse(io.IOBase):
                     # case, let's avoid swallowing SSL errors.
                     raise
 
-                raise ReadTimeoutError(self._pool, None, "Read timed out.")
+                raise ReadTimeoutError(self._pool, self._request_url, "Read timed out.")
 
             except (HTTPException, SocketError) as e:
                 # This includes IncompleteRead.


### PR DESCRIPTION
What:
Included the request URL in the `ReadTimeoutError` raised when a socket timeout occurs during a read operation in `urllib3/response.py`.

Why:
To provide more context when debugging timeout issues. Previously, the URL was `None` in these errors.

Verification:
Created a mock environment script to simulate the timeout during a read operation and confirmed that the generated `ReadTimeoutError` now contains the expected URL. Also ran the full test suite to ensure no regressions.

Result:
`ReadTimeoutError` now includes the requested URL instead of `None`.

---
*PR created automatically by Jules for task [7282406681853378457](https://jules.google.com/task/7282406681853378457) started by @ManupaKDU*