### PR TITLE
feat: Add optional socket.gethostbyname checking to urllib3 is_same_host

### DIFF
--- a/Learning/Part-1/Lib/site-packages/pip-19.0.3-py3.8.egg/pip/_vendor/urllib3/connectionpool.py
+++ b/Learning/Part-1/Lib/site-packages/pip-19.0.3-py3.8.egg/pip/_vendor/urllib3/connectionpool.py
@@ -422,7 +422,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         except queue.Empty:
             pass  # Done.
 
-    def is_same_host(self, url):
+    def is_same_host(self, url, check_host_ip=False):
         """
         Check if the given ``url`` is a member of the same host as this
         connection pool.
@@ -430,7 +430,6 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         if url.startswith('/'):
             return True
 
-        # TODO: Add optional support for socket.gethostbyname checking.
         scheme, host, port = get_host(url)
 
         host = _ipv6_host(host, self.scheme)
@@ -441,7 +440,16 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         elif not self.port and port == port_by_scheme.get(scheme):
             port = None
 
-        return (scheme, host, port) == (self.scheme, self.host, self.port)
+        is_same = (scheme, host, port) == (self.scheme, self.host, self.port)
+        if not is_same and check_host_ip and host and self.host:
+            is_same_scheme_port = (scheme, port) == (self.scheme, self.port)
+            if is_same_scheme_port:
+                try:
+                    is_same = socket.gethostbyname(host) == socket.gethostbyname(self.host)
+                except SocketError:
+                    pass
+
+        return is_same
 
     def urlopen(self, method, url, body=None, headers=None, retries=None,
                 redirect=True, assert_same_host=True, timeout=_Default,

--- a/Learning/Part-1/Lib/site-packages/urllib3/connectionpool.py
+++ b/Learning/Part-1/Lib/site-packages/urllib3/connectionpool.py
@@ -475,7 +475,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         except queue.Empty:
             pass  # Done.
 
-    def is_same_host(self, url):
+    def is_same_host(self, url, check_host_ip=False):
         """
         Check if the given ``url`` is a member of the same host as this
         connection pool.
@@ -483,7 +483,6 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         if url.startswith("/"):
             return True
 
-        # TODO: Add optional support for socket.gethostbyname checking.
         scheme, host, port = get_host(url)
         if host is not None:
             host = _normalize_host(host, scheme=scheme)
@@ -494,7 +493,16 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         elif not self.port and port == port_by_scheme.get(scheme):
             port = None
 
-        return (scheme, host, port) == (self.scheme, self.host, self.port)
+        is_same = (scheme, host, port) == (self.scheme, self.host, self.port)
+        if not is_same and check_host_ip and host and self.host:
+            is_same_scheme_port = (scheme, port) == (self.scheme, self.port)
+            if is_same_scheme_port:
+                try:
+                    is_same = socket.gethostbyname(host) == socket.gethostbyname(self.host)
+                except SocketError:
+                    pass
+
+        return is_same
 
     def urlopen(
         self,


### PR DESCRIPTION
What: Added `check_host_ip=False` as an optional argument to `is_same_host` in `urllib3/connectionpool.py` and `pip/_vendor/urllib3/connectionpool.py`. When enabled, and if the scheme and port match, it resolves mismatched host strings to their underlying IP addresses using `socket.gethostbyname` to verify if they point to the same server.
Coverage: Replaced the inline `TODO`. Tested via isolated mock test scripts due to broken internal vendor references preventing full standard test suite runs.
Result: The `is_same_host` method can now optionally verify hosts by IP, safely ignoring DNS resolution failures, and without breaking or degrading the performance of default standard HTTP clients.

---
*PR created automatically by Jules for task [8595431895314620677](https://jules.google.com/task/8595431895314620677) started by @ManupaKDU*