### PR TITLE
⚡ Include URL in ReadTimeoutError

### DIFF
--- a/Learning/Part-1/Lib/site-packages/pip-19.0.3-py3.8.egg/pip/_vendor/urllib3/response.py
+++ b/Learning/Part-1/Lib/site-packages/pip-19.0.3-py3.8.egg/pip/_vendor/urllib3/response.py
@@ -360,9 +360,7 @@ class HTTPResponse(io.IOBase):
                 yield
 
             except SocketTimeout:
-                # FIXME: Ideally we'd like to include the url in the ReadTimeoutError but
-                # there is yet no clean way to get at it from this context.
-                raise ReadTimeoutError(self._pool, None, 'Read timed out.')
+                raise ReadTimeoutError(self._pool, self._request_url, 'Read timed out.')
 
             except BaseSSLError as e:
                 # FIXME: Is there a better way to differentiate between SSLErrors?
@@ -371,7 +369,7 @@ class HTTPResponse(io.IOBase):
                     # case, let's avoid swallowing SSL errors.
                     raise
 
-                raise ReadTimeoutError(self._pool, None, 'Read timed out.')
+                raise ReadTimeoutError(self._pool, self._request_url, 'Read timed out.')
 
             except (HTTPException, SocketError) as e:
                 # This includes IncompleteRead.


### PR DESCRIPTION
What: Attached `self._request_url` to `ReadTimeoutError` inside `urllib3/response.py` instead of passing `None`, and removed the outdated FIXME comments.
Coverage: Verified changes manually and ensured python files still compile; existing tests have been run.
Result: When a `ReadTimeoutError` occurs during a read operation, it will now properly include the URL that was the source of the timeout.

---
*PR created automatically by Jules for task [5122188259122166258](https://jules.google.com/task/5122188259122166258) started by @ManupaKDU*