### PR TITLE
Refactor is_response_to_head to use public method attribute

### DIFF
--- a/Learning/Part-1/Lib/site-packages/urllib3/util/response.py
+++ b/Learning/Part-1/Lib/site-packages/urllib3/util/response.py
@@ -79,8 +79,9 @@ def is_response_to_head(response):
     :param conn:
     :type conn: :class:`httplib.HTTPResponse`
     """
-    # FIXME: Can we do this somehow without accessing private httplib _method?
-    method = response._method
+    method = getattr(response, "method", getattr(response, "_method", None))
     if isinstance(method, int):  # Platform-specific: Appengine
         return method == 3
+    if method is None:
+        return False
     return method.upper() == "HEAD"


### PR DESCRIPTION
What: Refactored `urllib3.util.response.is_response_to_head` to safely handle HTTPResponse method introspection using public attributes.
Coverage: Verified changes against mocked `HTTPResponse` objects simulating both public/private attributes and null states.
Result: The code avoids crashing if the attribute is absent, avoids exclusive dependency on a private attribute (`_method`), and resolves the `FIXME` comment.

---
*PR created automatically by Jules for task [12373598141596411878](https://jules.google.com/task/12373598141596411878) started by @ManupaKDU*